### PR TITLE
Add red background to counter

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -19,3 +19,7 @@ button {
 button:hover {
     background-color: #ccc;
 }
+
+#contador {
+    background-color: red;
+}


### PR DESCRIPTION
Add a red background to the counter element.

* Add a CSS rule in `styles.css` to set the background color of the `#contador` element to red.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/estebancalabria/gh-copilot-worspace-demo/pull/1?shareId=2cf0299a-48ef-4799-a1b5-d31fed7e4639).

## Summary by Sourcery

Enhancements:
- Style the counter element with a red background.